### PR TITLE
Add SEO metadata and crawler directives

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://iccv2025-found-workshop.limitlab.xyz/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://iccv2025-found-workshop.limitlab.xyz/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-found-workshop.limitlab.xyz/call-for-papers</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-found-workshop.limitlab.xyz/program</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-found-workshop.limitlab.xyz/organizers</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://iccv2025-found-workshop.limitlab.xyz/contact</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -9,6 +9,7 @@ import {
 
 import type { Route } from "./+types/root";
 import "./app.css";
+import { createMeta } from "@/lib/metadata";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -22,6 +23,8 @@ export const links: Route.LinksFunction = () => [
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];
+
+export const meta: Route.MetaFunction = () => createMeta();
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/routes/CallForPapers.tsx
+++ b/src/app/routes/CallForPapers.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link, type MetaFunction } from "react-router";
 // import { Download, ExternalLink } from "lucide-react";
 import { Calendar } from "lucide-react";
 
@@ -11,6 +11,15 @@ import { Button } from "../../components/ui/button";
 // } from "../../components/ui/accordion";
 import callForPapersData from "../../data/callForPapers.json";
 import scheduleData from "../../data/schedule.json";
+import { createMeta } from "@/lib/metadata";
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: "Call for Papers",
+    description:
+      "Review submission dates, topics of interest, and guidelines for contributing research to the FOUND Workshop at ICCV 2025.",
+    path: "/call-for-papers",
+  });
 
 function CallForPapers() {
   return (

--- a/src/app/routes/Contact.tsx
+++ b/src/app/routes/Contact.tsx
@@ -1,3 +1,4 @@
+import type { MetaFunction } from "react-router";
 import { Mail, MapPin } from "lucide-react";
 import { SiSlack } from "react-icons/si";
 
@@ -12,6 +13,16 @@ import {
 // import { Label } from "../../components/ui/label";
 // import { Textarea } from "../../components/ui/textarea";
 import contactData from "../../data/contact.json";
+
+import { createMeta } from "@/lib/metadata";
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: "Contact",
+    description:
+      "Find email, location, and community channels to reach the FOUND Workshop organizers at ICCV 2025.",
+    path: "/contact",
+  });
 
 function Contact() {
   return (

--- a/src/app/routes/Home.tsx
+++ b/src/app/routes/Home.tsx
@@ -1,9 +1,18 @@
-import { Link } from "react-router";
+import { Link, type MetaFunction } from "react-router";
 import { Calendar, MapPin } from "lucide-react";
 
 import { Button } from "../../components/ui/button";
 import homeData from "../../data/home.json";
 import scheduleData from "../../data/schedule.json";
+import { createMeta } from "@/lib/metadata";
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: "Foundation Data for Industrial Tech Transfer",
+    description:
+      "Explore the FOUND Workshop at ICCV 2025, where researchers discuss adapting foundation models, next-generation evaluation metrics, and the key dates for participation.",
+    path: "/",
+  });
 
 function Home() {
   return (

--- a/src/app/routes/Organizers.tsx
+++ b/src/app/routes/Organizers.tsx
@@ -1,3 +1,4 @@
+import type { MetaFunction } from "react-router";
 import { ExternalLink } from "lucide-react";
 
 import { Button } from "../../components/ui/button";
@@ -10,6 +11,16 @@ import {
   CardTitle,
 } from "../../components/ui/card";
 import organizersData from "../../data/organizers.json";
+
+import { createMeta } from "@/lib/metadata";
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: "Organizers",
+    description:
+      "Meet the organizing committee and supporters behind the FOUND Workshop at ICCV 2025.",
+    path: "/organizers",
+  });
 
 function Organizers() {
   return (

--- a/src/app/routes/Program.tsx
+++ b/src/app/routes/Program.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink } from "lucide-react";
-import { Calendar, MapPin } from "lucide-react";
+import type { MetaFunction } from "react-router";
+import { Calendar, ExternalLink, MapPin } from "lucide-react";
 
 import { Button } from "../../components/ui/button";
 import {
@@ -21,6 +21,15 @@ import {
 import programData from "../../data/program.json";
 import scheduleData from "../../data/schedule.json";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { createMeta } from "@/lib/metadata";
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: "Program",
+    description:
+      "Preview the FOUND Workshop schedule, featured sessions, and invited speakers taking place at ICCV 2025.",
+    path: "/program",
+  });
 
 function Program() {
   return (

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,68 @@
+import type { MetaFunction } from "react-router";
+
+const BASE_URL = "https://iccv2025-found-workshop.limitlab.xyz";
+
+export const siteMetadata = {
+  siteName: "FOUND Workshop",
+  baseTitle: "FOUND Workshop at ICCV 2025",
+  description:
+    "FOUND (Foundation Data for Industrial Tech Transfer) Workshop at ICCV 2025 brings together industry and academic leaders to share advances in adapting foundation models and designing next-generation evaluation tasks.",
+  keywords: [
+    "ICCV 2025",
+    "FOUND Workshop",
+    "foundation models",
+    "tech transfer",
+    "computer vision",
+    "foundation data",
+  ],
+  baseUrl: BASE_URL,
+};
+
+type MetaDescriptors = Exclude<ReturnType<MetaFunction>, undefined>;
+
+type CreateMetaArgs = {
+  title?: string;
+  description?: string;
+  path?: string;
+};
+
+function resolveUrl(path?: string) {
+  if (!path) {
+    return siteMetadata.baseUrl;
+  }
+
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return new URL(normalizedPath, siteMetadata.baseUrl).toString();
+}
+
+export function createMeta({
+  title,
+  description,
+  path,
+}: CreateMetaArgs = {}): MetaDescriptors {
+  const pageTitle = title
+    ? `${title} | ${siteMetadata.baseTitle}`
+    : siteMetadata.baseTitle;
+  const pageDescription = description ?? siteMetadata.description;
+  const keywords = siteMetadata.keywords.join(", ");
+  const canonicalUrl = resolveUrl(path);
+
+  return [
+    { title: pageTitle },
+    { name: "description", content: pageDescription },
+    { name: "keywords", content: keywords },
+    { property: "og:title", content: pageTitle },
+    { property: "og:description", content: pageDescription },
+    { property: "og:url", content: canonicalUrl },
+    { property: "og:type", content: "website" },
+    { property: "og:site_name", content: siteMetadata.siteName },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: pageTitle },
+    { name: "twitter:description", content: pageDescription },
+    { tagName: "link", rel: "canonical", href: canonicalUrl },
+  ];
+}


### PR DESCRIPTION
## Summary
- add a shared metadata helper and export meta functions for the root layout and key routes so each page provides descriptive titles, descriptions, canonical URLs, and social tags
- publish robots.txt and sitemap.xml to guide crawlers toward the workshop’s main pages

## Testing
- yarn lint
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cf93cc20788326b880fd535c19630f