### PR TITLE
Add Google Search Console verification meta tag

### DIFF
--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -32,6 +32,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="google-site-verification"
+          content="ji-hT4NRIusCUNz2z3vvVhqAUrEYfdUgEbj_Z-K39B0"
+        />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
## Summary
- add the Google Search Console site verification meta tag to the app layout head so the homepage includes it

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d1157f70cc8326a4c8a5feef763e63