### PR TITLE
Add sponsorship page and navigation links

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://iccv2025-found-workshop.limitlab.xyz/sponsorship</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://iccv2025-found-workshop.limitlab.xyz/organizers</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -12,6 +12,7 @@ export default [
     // route("/schedule", "./routes/Schedule.tsx"),
     route("/program", "./routes/Program.tsx"),
     route("/organizers", "./routes/Organizers.tsx"),
+    route("/sponsorship", "./routes/Sponsorship.tsx"),
     // route("/past-events", "./routes/PastEvents.tsx"),
     route("/contact", "./routes/Contact.tsx"),
   ]),

--- a/src/app/routes/Sponsorship.tsx
+++ b/src/app/routes/Sponsorship.tsx
@@ -1,0 +1,146 @@
+import type { MetaFunction } from "react-router";
+import { Link } from "react-router";
+
+import { Button } from "../../components/ui/button";
+import { createMeta } from "@/lib/metadata";
+
+export const meta: MetaFunction = () =>
+  createMeta({
+    title: "Sponsorship Opportunities",
+    description:
+      "Explore sponsorship opportunities for the FOUND and LIMIT workshops at ICCV 2025, including benefits, visibility, and contact information.",
+    path: "/sponsorship",
+  });
+
+function Sponsorship() {
+  return (
+    <main className="container px-6 py-8 space-y-12 xl:w-6xl">
+      <section className="space-y-4 text-center">
+        <div className="space-y-2">
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tighter">
+            Sponsorship Opportunities
+          </h1>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl sm:text-3xl font-bold tracking-tighter">
+            Support FOUND Workshop
+          </h2>
+          <div className="space-y-4 text-left">
+            <p>
+              The ICCV 2025 Workshop on <strong>Foundation Data (FOUND)</strong>
+              is now welcoming sponsors. We invite industry partners who wish to
+              engage with the international computer vision research community
+              and support the workshop&#39;s activities. Sponsors will be
+              acknowledged on the FOUND workshop website and during the event.
+            </p>
+            <p>
+              As the FOUND and{" "}
+              <strong>
+                <a
+                  href="https://iccv2025-limit-workshop.limitlab.xyz/"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  Learning with Very Limited Resources (LIMIT)
+                </a>
+              </strong>{" "}
+              workshops will jointly host the social event, sponsorship is
+              shared across both workshops. This means that the{" "}
+              <strong>Benefits for Sponsors</strong> listed below will apply to
+              both the FOUND and LIMIT workshops.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl sm:text-3xl font-bold tracking-tighter">
+            Benefits for Sponsors
+          </h2>
+          <div className="space-y-6">
+            <ul className="space-y-6">
+              <li className="space-y-2">
+                <h3 className="text-xl font-semibold">
+                  Short Introduction at Social Event
+                </h3>
+                <p>
+                  Each sponsor will have a few minutes to introduce their
+                  organization during the social event following the workshop.
+                </p>
+              </li>
+              <li className="space-y-2">
+                <h3 className="text-xl font-semibold">
+                  Booth Space for Novelties
+                </h3>
+                <p>
+                  A small table or space will be available for distributing
+                  company novelties or informational materials.
+                </p>
+              </li>
+              <li className="space-y-2">
+                <h3 className="text-xl font-semibold">
+                  Visibility on Website and Program
+                </h3>
+                <p>
+                  Sponsor logos will be displayed on the workshop website and in
+                  the program materials.
+                </p>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl sm:text-3xl font-bold tracking-tighter">
+            Why Sponsor?
+          </h2>
+          <div className="space-y-4">
+            <p>Supporting the workshop provides a unique opportunity to:</p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Connect with leading researchers and students in computer
+                vision.
+              </li>
+              <li>
+                Increase visibility within the academic and industrial
+                community.
+              </li>
+              <li>
+                Promote your organization&#39;s vision, products, and career
+                opportunities.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl sm:text-3xl font-bold tracking-tighter">
+            Contact
+          </h2>
+          <div className="space-y-4">
+            <p>
+              If your organization is interested in becoming a sponsor, please
+              contact us:
+            </p>
+            <div>
+              <Button variant="outline" asChild>
+                <Link to="/contact">Contact Us</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default Sponsorship;

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -96,6 +96,18 @@ export function Footer() {
             Program
           </Link>
           <Link
+            to="/organizers"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Organizers
+          </Link>
+          <Link
+            to="/sponsorship"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            Sponsorship Opportunities
+          </Link>
+          <Link
             to="/contact"
             className="text-sm text-muted-foreground hover:text-foreground"
           >

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,6 +17,7 @@ const navItems = [
   // { name: "Schedule", path: "/iccv2025/schedule" },
   { name: "Program", path: "/program" },
   { name: "Organizers", path: "/organizers" },
+  { name: "Sponsorship Opportunities", path: "/sponsorship" },
   // { name: "Past Events", path: "/iccv2025/past-events" },
   { name: "Contact", path: "/contact" },
 ];


### PR DESCRIPTION
## Summary
- add a dedicated sponsorship route and page with metadata
- surface the sponsorship page in the header and footer navigation

## Testing
- not run (not requested)
