### PR TITLE
Update Shashanka Venkataramanan affiliation

### DIFF
--- a/src/data/program.json
+++ b/src/data/program.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "Shashanka Venkataramanan",
-      "affiliation": "INRIA",
+      "affiliation": "Valeo.ai",
       "photo": "/program/shashanka.venkataramanan-512x512.jpg",
       "title": "",
       "bio": "",


### PR DESCRIPTION
## Summary
- update the invited speaker data so that Shashanka Venkataramanan is listed with the Valeo.ai affiliation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e868c8151c8326b54ead7219b23e98