### PR TITLE
Emphasize Exhibit Hall II location

### DIFF
--- a/src/app/routes/Program.tsx
+++ b/src/app/routes/Program.tsx
@@ -171,7 +171,8 @@ function Program() {
             >
               ICCV official website
             </a>
-            .
+            . Please display your poster on the assigned poster board number in{" "}
+            <span className="font-semibold">Exhibit Hall II</span>.
           </p>
         </div>
         <div className="relative border-border space-y-8">


### PR DESCRIPTION
## Summary
- emphasize Exhibit Hall II as the poster display location
- bold the venue text so presenters notice it