### PR TITLE
Add latest news entries to home page data

### DIFF
--- a/src/data/home.json
+++ b/src/data/home.json
@@ -35,6 +35,16 @@
   ],
   "latestNews": [
     {
+      "title": "Workshop successfully concluded",
+      "date": "October 19, 2025",
+      "content": "The workshop was successfully held with many participants. We sincerely thank all presenters and contributors for their valuable contributions."
+    },
+    {
+      "title": "Sponsor Information Released",
+      "date": "October 18, 2025",
+      "content": "We are delighted to share that three companies have joined us as sponsors. We sincerely thank them for their generous support."
+    },
+    {
       "title": "Program announcement",
       "date": "September 1, 2025",
       "content": "The workshop program has been published."


### PR DESCRIPTION
## Summary
- add two new latest news entries reflecting recent workshop updates

## Testing
- not run